### PR TITLE
Add quadratic and cubic shape functions

### DIFF
--- a/plutho/mesh/gmsh_parser.py
+++ b/plutho/mesh/gmsh_parser.py
@@ -67,29 +67,57 @@ class GmshParser:
         element_types,
         element_tags,
         element_node_tags
-    ) -> npt.NDArray:
-        """Returns a list of elements used in the simulation from the gmsh
-        getElements() api function.
+    ) -> Dict[int, npt.NDArray]:
+        """
+        For each given element type a list of elements is returned.
 
         Parameters:
-            element_types: Element types from gmsh api.
-            element_tags: Tags of the element per element type.
-            element_node_tags: Tags of the nodes per element tag.
+            element_types: List of element types for which the elements lists
+                are extracted.
+            element_tags: Tags of the elements per element type.
+            element_node_tags: Tags of the nodes of the elements per element
+                type.
 
         Returns:
-            A list of lists where each inner list contains the node indices for
-            the triangle at the outer list index.
+            A list of elements for each given element type:
+            List of elements [e1, e2, e3, ...] where each element consists of
+            its node tags: e1: [n1, n2, ...].
         """
-        nodes_per_element = element_to_nodes_map[2, self.element_order]
-        elements = []
-        element_indices = []
-        # Entity elements of theset dimension containing the smaller elements
-        # Since every entity consists of multiple elements iterate over all
-        # entities and extract the elements
-        for i, _ in enumerate(element_types):
+        elements_per_type = {}
+
+        # Types of the given elements: 2D -> Triangle or 1D -> Line
+        # Iterate over all given types
+        for i, element_type in enumerate(element_types):
+            elements = []
+            element_indices = []
+
+            # For each type get the order to calculate the number of nodes
+            # it consists of
+            _, dim, order, _, _, _ = \
+                gmsh.model.mesh.getElementProperties(
+                    element_type
+                )
+
+            match dim:
+                case 0:
+                    nodes_per_element = 1
+                case 1:
+                    # Line element
+                    nodes_per_element = order+1
+                case 2:
+                    # Triangle element
+                    nodes_per_element = int(1/2*(order+1)*(order+2))
+                case _:
+                    raise ValueError("Only supporting 2D meshes")
+
+            # The element tags and element_node_tags lists are nested lists
+            # which contain the element tags and node tags of the elements of
+            # the current type at the respective index
             current_element_tags = element_tags[i]
             current_node_tags = element_node_tags[i]
-            # For each element of which the entity consists
+
+            # Now iterate over every element of the current type and extract
+            # the node indices
             for j, _ in enumerate(current_element_tags):
                 # 1 is subtracted because the indices in gmsh start with 1.
                 elements.append(current_node_tags[
@@ -98,19 +126,21 @@ class GmshParser:
                 )
                 element_indices.append(j)
 
-        if len(elements) == 0:
-            raise ValueError(
-                "Couldn't return elements because the list is empty."
+            if len(elements) == 0:
+                raise ValueError(
+                    "Couldn't return elements because the list is empty."
+                )
+
+            elements_np = np.zeros(
+                shape=(len(current_element_tags), nodes_per_element),
+                dtype=int
             )
+            for index, element in zip(element_indices, elements):
+                elements_np[index] = element
 
-        elements_np = np.zeros(
-            shape=(len(elements), len(elements[0])),
-            dtype=int
-        )
-        for index, element in zip(element_indices, elements):
-            elements_np[index] = element
+            elements_per_type[element_type] = elements_np
 
-        return elements_np
+        return elements_per_type
 
     def get_mesh_nodes_and_elements(self) -> Tuple[npt.NDArray, npt.NDArray]:
         """Creates the nodes and elements lists as used in the simulation.
@@ -118,7 +148,20 @@ class GmshParser:
         Returns:
             List of nodes and elements"""
         nodes = self._get_nodes(*gmsh.model.mesh.getNodes())
-        elements = self._get_elements(*gmsh.model.mesh.getElements(dim=2))
+
+        el_types, el_tags, el_node_tags = gmsh.model.mesh.getElements(dim=2)
+        elements_per_type = self._get_elements(
+            el_types, el_tags, el_node_tags
+        )
+
+        if len(elements_per_type) != 1:
+            raise ValueError(
+                "The given mesh as more (or less) than one element type for "
+                "dim=2"
+            )
+
+        # There should be only one element type for dim=2
+        elements = elements_per_type[el_types[0]]
 
         return nodes, elements
 
@@ -160,42 +203,42 @@ class GmshParser:
         self,
         needed_pg_names: List[str]
     ) -> Dict[str, npt.NDArray]:
-        """Returns the elements inside the given physical groups.
+        """Get all triangle elements for the given physical group.
 
         Parameters:
             needed_pg_names: List of names of physical groups for which the
-                triangles are returned.
+                triangle elements shall be returned.
 
         Returns:
-            Dictionary where keys are the pg names and the values are a list
-            of triangles of this physical group."""
-        nodes_on_boundary = element_to_boundary_nodes_map[
-            self.element_order
-        ]
-        pg_tags = self.get_nodes_by_physical_groups(needed_pg_names)
-        elements = self._get_elements(*gmsh.model.mesh.getElements(dim=2))
-        triangle_elements = {}
-        for pg_name, nodes in pg_tags.items():
-            current_triangle_elements = []
-            for check_element in elements:
-                # If at least {nodes_on_boundary} nodes of the check_element
-                # are inside of the nodes list of the current physical group,
-                # then the element is also part of the physical group.
-                found_count = 0
+            dictionary where the key is the physical group name and the value
+            is a list of elements for this pg.
+        """
+        _, elements = self.get_mesh_nodes_and_elements()
+        pg_nodes = self.get_nodes_by_physical_groups(needed_pg_names)
+        element_order = self.element_order
+        nodes_per_line = element_order+1
+        pg_elements = {}
 
-                for ce in check_element:
-                    if ce in nodes:
-                        found_count += 1
+        for pg_name in needed_pg_names:
+            nodes = pg_nodes[pg_name]
 
-                if found_count >= nodes_on_boundary:
-                    current_triangle_elements.append(check_element)
+            # For every possible element, check if it contains 'enought' nodes
+            # from the physical group -> Then add it to the elements list
+            # TODO Rework this: Check if its also possible to return
+            # element lists containing line elements.
+            current_elements = []
+            for element in elements:
+                count = 0
+                for node_index in element:
+                    if node_index in nodes:
+                        count += 1
 
-            triangle_elements[pg_name] = np.array(
-                current_triangle_elements,
-                dtype=int
-            )
+                if count >= nodes_per_line:
+                    current_elements.append(element)
 
-        return triangle_elements
+            pg_elements[pg_name] = np.array(current_elements)
+
+        return pg_elements
 
     def create_element_post_processing_view(
         self,

--- a/plutho/mesh/mesh.py
+++ b/plutho/mesh/mesh.py
@@ -23,6 +23,7 @@ class Mesh:
     mesh_file_path: str
     file_version: str
     parser: Union[GmshParser, CustomParser]
+    element_order: int
 
     def __init__(
         self,
@@ -33,6 +34,7 @@ class Mesh:
             raise IOError(f"Mesh file {file_path} not found.")
 
         self.mesh_file_path = file_path
+        self.element_order = element_order
 
         # Check gmsh version
         # If version2  -> custom gmsh parser

--- a/plutho/mesh/mesh.py
+++ b/plutho/mesh/mesh.py
@@ -6,6 +6,7 @@ from typing import Union, Tuple, Dict, List
 
 # Third party libraries
 import gmsh
+import numpy as np
 import numpy.typing as npt
 
 # Local libraries
@@ -26,6 +27,7 @@ class Mesh:
     def __init__(
         self,
         file_path: str,
+        element_order: int
     ):
         if not os.path.isfile(file_path):
             raise IOError(f"Mesh file {file_path} not found.")
@@ -46,9 +48,9 @@ class Mesh:
             self.file_version = version
 
         if version.startswith("2"):
-            self.parser = CustomParser(file_path)
+            self.parser = CustomParser(file_path, element_order)
         else:
-            self.parser = GmshParser(file_path)
+            self.parser = GmshParser(file_path, element_order)
 
     def get_mesh_nodes_and_elements(self) -> Tuple[npt.NDArray, npt.NDArray]:
         return self.parser.get_mesh_nodes_and_elements()

--- a/plutho/mesh/mesh.py
+++ b/plutho/mesh/mesh.py
@@ -106,7 +106,8 @@ class Mesh:
         width: float = 0.005,
         height: float = 0.001,
         mesh_size: float = 0.00015,
-        x_offset: float = 0
+        x_offset: float = 0,
+        element_order: int = 1
     ):
         """Creates a gmsh rectangular mesh given the width, height, the mesh
         size and the x_offset.
@@ -125,6 +126,7 @@ class Mesh:
             gmsh.initialize()
 
         gmsh.clear()
+        gmsh.option.setNumber("Mesh.ElementOrder", element_order)
 
         corner_points = [
             [x_offset, 0],

--- a/plutho/postprocessing.py
+++ b/plutho/postprocessing.py
@@ -59,6 +59,7 @@ def calculate_stored_thermal_energy(
     theta: npt.NDArray,
     nodes: npt.NDArray,
     elements: npt.NDArray,
+    element_order: int,
     heat_capacity: float,
     density: float
 ) -> Union[float, npt.NDArray]:
@@ -77,33 +78,33 @@ def calculate_stored_thermal_energy(
     Returns:
         The stored energy either as float or list of floats.
     """
+    points_per_element = int(1/2*(element_order+1)*(element_order+2))
 
     if len(theta.shape) == 2:
         # Need to calculate for every time step
         stored_energies = np.zeros(theta.shape[1])
 
         for time_index in range(theta.shape[1]):
-            for element in elements:
-                dn = gradient_local_shape_functions_2d()
-                node_points = np.array([
-                    [nodes[element[0]][0],
-                     nodes[element[1]][0],
-                     nodes[element[2]][0]],
-                    [nodes[element[0]][1],
-                     nodes[element[1]][1],
-                     nodes[element[2]][1]]
-                ])
-                jacobian = np.dot(node_points, dn.T)
-                jacobian_det = np.linalg.det(jacobian)
-                theta_e = np.array([
-                    theta[element[0], time_index],
-                    theta[element[1], time_index],
-                    theta[element[2], time_index]
-                ])
+            for element_index, element in enumerate(elements):
+                node_points = np.zeros(shape=(2, points_per_element))
+                for node_index in range(points_per_element):
+                    node_points[:, node_index] = [
+                        nodes[element[node_index]][0],
+                        nodes[element[node_index]][1]
+                    ]
+
+                theta_e = np.zeros(points_per_element)
+                for node_index in range(points_per_element):
+                    theta_e[node_index] = theta[
+                        element[node_index],
+                        time_index
+                    ]
+
                 stored_energies[time_index] += energy_integral_theta(
                     node_points,
-                    theta_e
-                ) * 2 * np.pi * jacobian_det * heat_capacity * density
+                    theta_e,
+                    element_order
+                ) * 2 * np.pi * heat_capacity * density
 
         return stored_energies
 
@@ -111,28 +112,27 @@ def calculate_stored_thermal_energy(
         # Only one time step
         stored_energy = 0
 
-        for element in elements:
-            dn = gradient_local_shape_functions_2d()
-            node_points = np.array([
-                [nodes[element[0]][0],
-                 nodes[element[1]][0],
-                 nodes[element[2]][0]],
-                [nodes[element[0]][1],
-                 nodes[element[1]][1],
-                 nodes[element[2]][1]]
-            ])
-            jacobian = np.dot(node_points, dn.T)
-            jacobian_det = np.linalg.det(jacobian)
-            theta_e = np.array([
-                theta[element[0]],
-                theta[element[1]],
-                theta[element[2]]
-            ])
+        for element_index, element in enumerate(elements):
+            node_points = np.zeros(shape=(2, points_per_element))
+            for node_index in range(points_per_element):
+                node_points[:, node_index] = [
+                    nodes[element[node_index]][0],
+                    nodes[element[node_index]][1]
+                ]
+
+            theta_e = np.zeros(points_per_element)
+            for node_index in range(points_per_element):
+                theta_e[node_index] = theta[element[node_index]]
+
             stored_energy += energy_integral_theta(
                 node_points,
-                theta_e
-            ) * 2 * np.pi * jacobian_det * heat_capacity * density
+                theta_e,
+                element_order
+            ) * 2 * np.pi * heat_capacity * density
 
         return stored_energy
 
-    return -1
+    raise ValueError(
+        "Cannot calculate total stored energy for given "
+        f"{len(theta.shape)}-dimensional theta"
+    )

--- a/plutho/postprocessing.py
+++ b/plutho/postprocessing.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 
 # Local libraries
 from plutho.simulation.base import energy_integral_theta, \
-    gradient_local_shape_functions
+    gradient_local_shape_functions_2d
 
 
 def calculate_impedance(
@@ -84,7 +84,7 @@ def calculate_stored_thermal_energy(
 
         for time_index in range(theta.shape[1]):
             for element in elements:
-                dn = gradient_local_shape_functions()
+                dn = gradient_local_shape_functions_2d()
                 node_points = np.array([
                     [nodes[element[0]][0],
                      nodes[element[1]][0],
@@ -112,7 +112,7 @@ def calculate_stored_thermal_energy(
         stored_energy = 0
 
         for element in elements:
-            dn = gradient_local_shape_functions()
+            dn = gradient_local_shape_functions_2d()
             node_points = np.array([
                 [nodes[element[0]][0],
                  nodes[element[1]][0],

--- a/plutho/simulation/base.py
+++ b/plutho/simulation/base.py
@@ -298,7 +298,7 @@ def b_operator_global(
     Returns:
         B operator 4x6, for a u aligned like [u1_r, u1_z, u2_r, u2_z, ..].
     """
-    dim = int(1/2*(element_order+1)*(element_order+2))
+    nodes_per_element = int(1/2*(element_order+1)*(element_order+2))
 
     # Get local shape functions and r (because of theta component)
     n = local_shape_functions_2d(s, t)
@@ -311,8 +311,8 @@ def b_operator_global(
     global_dn = np.dot(jacobian_inverted_t, dn)
 
     # Initialize and fill array
-    b = np.zeros(shape=(4, 2*dim))
-    for d in range(dim):
+    b = np.zeros(shape=(4, 2*nodes_per_element))
+    for d in range(nodes_per_element):
         b[:, 2*d:2*d+2] = [
             [
                 global_dn[0][d], 0
@@ -493,7 +493,7 @@ def energy_integral_theta(
         n = local_shape_functions_2d(s, t, element_order)
         r = local_to_global_coordinates(node_points, s, t, element_order)[0]
 
-        return np.dot(n.T, theta) * r * jacobian_det
+        return np.dot(n.T, theta)*r*jacobian_det
 
     return quadratic_quadrature(inner, element_order)
 
@@ -846,7 +846,7 @@ def calculate_volumes(node_points: npt.NDArray, element_order):
     for element_index in range(number_of_elements):
         volumes.append(
             integral_volume(node_points[element_index], element_order)
-            * 2 * np.pi
+            *2*np.pi
         )
 
     return volumes

--- a/plutho/simulation/base.py
+++ b/plutho/simulation/base.py
@@ -216,8 +216,8 @@ def gradient_local_shape_functions_2d(s, t, element_order=1) -> npt.NDArray:
     match element_order:
         case 1:
             return np.array([
-                [-1, 1, 0],
-                [-1, 0, 1]
+                [-1, 1, 0],  # d_s
+                [-1, 0, 1]   # d_t
             ])
         case 2:
             return np.array([
@@ -239,7 +239,32 @@ def gradient_local_shape_functions_2d(s, t, element_order=1) -> npt.NDArray:
                 ]
             ])
         case 3:
-            pass
+            return np.array([
+                [  # d_s
+                    -13.5*s**2-27*s*t+18*s-13.5*t**2+18*t-5.5,
+                    13.5*s**2-9*s+1,
+                    0,
+                    40.5*s**2+54*s*t-45*s+13.5*t**2-22.5*t+9,
+                    -40.5*s**2-27*s*t+36*s+4.5*t-4.5,
+                    t*(27*s-4.5),
+                    t*(13.5*t-4.5),
+                    t*(4.5-13.5*t),
+                    t*(27*s+27*t-22.5),
+                    27*t*(-2*s-t+1)
+                ],
+                [  # d_t
+                    -13.5*s**2-27*s*t+18*s-13.5*t**2+18*t-5.5,
+                    0,
+                    13.5*t**2-9*t+1,
+                    s*(27*s+27*t-22.5),
+                    s*(4.5-13.5*s),
+                    s*(13.5*s-4.5),
+                    s*(27*t-4.5),
+                    -27*s*t+4.5*s-40.5*t**2+36*t-4.5,
+                    13.5*s**2+54*s*t-22.5*s+40.5*t**2-45*t+9,
+                    27*s*(-s-2*t+1)
+                ]
+            ])
 
     raise ValueError(
         "Gradient of shape functions not implemented for element "

--- a/plutho/simulation/base.py
+++ b/plutho/simulation/base.py
@@ -145,7 +145,7 @@ class MaterialData:
 # -------- Local functions and integrals --------
 
 
-def local_shape_functions_2d(s, t, element_order=1):
+def local_shape_functions_2d(s, t, element_order):
     """Returns the local linear shape functions based on a reference triangle
     with corner points [(0,0), (1,0), (1,1)] for the given coordinates.
 
@@ -199,7 +199,7 @@ def local_shape_functions_2d(s, t, element_order=1):
             )
 
 
-def gradient_local_shape_functions_2d(s, t, element_order=1) -> npt.NDArray:
+def gradient_local_shape_functions_2d(s, t, element_order) -> npt.NDArray:
     """Returns the gradient of the local shape functions.
 
     Parameters:
@@ -326,7 +326,7 @@ def b_operator_global(
     nodes_per_element = int(1/2*(element_order+1)*(element_order+2))
 
     # Get local shape functions and r (because of theta component)
-    n = local_shape_functions_2d(s, t)
+    n = local_shape_functions_2d(s, t, element_order)
     r = local_to_global_coordinates(node_points, s, t, element_order)[0]
 
     # Get gradients of local shape functions (s, t)

--- a/plutho/simulation/base.py
+++ b/plutho/simulation/base.py
@@ -347,7 +347,7 @@ def integral_m(node_points: npt.NDArray, element_order: int):
         jacobian = np.dot(node_points, dn.T)
         jacobian_det = np.linalg.det(jacobian)
 
-        n = local_shape_functions_2d(s, t)
+        n = local_shape_functions_2d(s, t, element_order)
 
         # Since the simulation is axisymmetric it is necessary
         # to multiply with the radius in the integral
@@ -535,7 +535,6 @@ def quadratic_quadrature(func: Callable, element_order: int):
     Returns:
         Integral of the given function.
     """
-    #f = np.vectorize(func)
     weights = []
     points = []
 
@@ -582,17 +581,12 @@ def quadratic_quadrature(func: Callable, element_order: int):
                 f"{element_order} implemented"
             )
 
-    # TODO
-    # Instead of a double for loop make a fast calculation using numpy
-    # The numpy calculations should be simular to
+    # TODO Can this made faster using numpy?
     sum = 0
     for i in range(len(weights)):
-        for j in range(len(weights)):
-            sum += weights[i]*weights[j]*func(points[i][0], points[j][1])
-    return sum
+        sum += weights[i]*func(points[i][0], points[i][1])
 
-    # F = f(points[:, 0], points[:, 1])
-    # return np.dot(np.dot(F, weights).T, weights)
+    return sum
 
 
 def line_quadrature(func: Callable, element_order: int):
@@ -606,7 +600,6 @@ def line_quadrature(func: Callable, element_order: int):
 
     Returns:
         Integral of the given function along r-axis"""
-    # f = np.vectorize(func)
     weights = []
     points = []
 
@@ -630,9 +623,7 @@ def line_quadrature(func: Callable, element_order: int):
                 f"{element_order} implemented"
             )
 
-    # TODO Make use of numpy
-    # return np.dot(f(points).T, weights)
-
+    # TODO Make use of numpy?
     sum = 0
     for i in range(len(weights)):
         sum += weights[i]*func(points[i])

--- a/plutho/simulation/nonlinear/piezo_stationary.py
+++ b/plutho/simulation/nonlinear/piezo_stationary.py
@@ -3,7 +3,7 @@ for the case of a time-stationary simulation. (d_t=0)
 """
 
 # Python standard libraries
-from typing import List, Union, Tuple
+from typing import Union, Tuple
 
 # Third party libraries
 import numpy as np
@@ -14,7 +14,7 @@ from scipy.sparse import linalg
 
 # Local libraries
 from .base import assemble, NonlinearType
-from ..base import MeshData, LocalElementData
+from ..base import MeshData
 from plutho.materials import MaterialManager
 
 
@@ -37,9 +37,6 @@ class NonlinearPiezoSimStationary:
     # FEM matrices
     k: sparse.lil_array
     ln: sparse.lil_array
-
-    # Internal simulation data
-    local_elements: List[LocalElementData]
 
     # Resulting fields
     u: npt.NDArray
@@ -86,7 +83,7 @@ class NonlinearPiezoSimStationary:
 
         # Calculate u using phi as load vector
         self.u = linalg.spsolve(
-            k.tocsc(),
+            k,
             f
         )
 
@@ -244,10 +241,10 @@ class NonlinearPiezoSimStationary:
 
     @staticmethod
     def apply_dirichlet_bc(
-        k: sparse.sparray,
-        ln: sparse.sparray,
+        k: sparse.lil_array,
+        ln: sparse.lil_array,
         nodes: npt.NDArray
-    ) -> Tuple[sparse.sparray, sparse.sparray]:
+    ) -> Tuple[sparse.csc_array, sparse.csc_array]:
         """Sets dirichlet boundary condition for the given matrix.
 
         Parameters:
@@ -264,4 +261,4 @@ class NonlinearPiezoSimStationary:
 
             k[node, node] = 1
 
-        return k, ln
+        return k.tocsc(), ln.tocsc()

--- a/plutho/simulation/nonlinear/piezo_time.py
+++ b/plutho/simulation/nonlinear/piezo_time.py
@@ -10,7 +10,7 @@ from scipy.sparse import linalg
 
 # Local libraries
 from .base import assemble, NonlinearType
-from ..base import SimulationData, MeshData, gradient_local_shape_functions, \
+from ..base import SimulationData, MeshData, gradient_local_shape_functions_2d, \
     LocalElementData
 from plutho.simulation.piezo_time import charge_integral_u, \
     charge_integral_v
@@ -328,7 +328,7 @@ class NonlinearPiezoSimTime:
         q = 0
 
         for element_index, element in enumerate(electrode_elements):
-            dn = gradient_local_shape_functions()
+            dn = gradient_local_shape_functions_2d()
             node_points = np.array([
                 [nodes[element[0]][0],
                  nodes[element[1]][0],

--- a/plutho/simulation/piezo_time.py
+++ b/plutho/simulation/piezo_time.py
@@ -12,7 +12,7 @@ from .base import SimulationData, MeshData, \
     gradient_local_shape_functions_2d, \
     local_to_global_coordinates, b_operator_global, integral_m, \
     integral_ku, integral_kuv, integral_kve, apply_dirichlet_bc, \
-    line_quadrature, create_local_element_data, LocalElementData
+    line_quadrature, create_node_points
 from ..materials import MaterialManager
 
 
@@ -20,7 +20,7 @@ def charge_integral_u(
     node_points: npt.NDArray,
     u_e: npt.NDArray,
     piezo_matrix: npt.NDArray,
-    jacobian_inverted_t: npt.NDArray
+    element_order: int
 ):
     """Calculates the integral of eBu of the given element.
 
@@ -30,31 +30,35 @@ def charge_integral_u(
         u_e: List of u values at the nodes of the triangle
             [u1_r, u1_z, u2_r, u2_z].
         piezo_matrix: Piezo matrix for the current element (e matrix).
-        jacobian_inverted_t: Jacobian matrix inverted and transposed, needed
-            for calculation of global derivatives.
+        element_order: Order of the shape functions.
 
     Returns:
         Float: Integral of eBu of the current triangle.
     """
     def inner(s):
-        r = local_to_global_coordinates(node_points, s, 0)[0]
+        dn = gradient_local_shape_functions_2d(s, 0, element_order)
+        jacobian = np.dot(node_points, dn.T)
+        jacobian_inverted_t = np.linalg.inv(jacobian).T
+
         b_opt_global = b_operator_global(
             node_points,
             jacobian_inverted_t,
             s,
-            0
+            0,
+            element_order
         )
+        r = local_to_global_coordinates(node_points, s, 0, element_order)[0]
 
         return -np.dot(np.dot(piezo_matrix, b_opt_global), u_e)*r
 
-    return line_quadrature(inner)
+    return line_quadrature(inner, element_order)
 
 
 def charge_integral_v(
     node_points: npt.NDArray,
     v_e: npt.NDArray,
     permittivity_matrix: npt.NDArray,
-    jacobian_inverted_t: npt.NDArray
+    element_order: int
 ):
     """Calculates the integral of epsilonBVe of the given element.
 
@@ -65,20 +69,22 @@ def charge_integral_v(
             [v1, v2].
         permittivity_matrix: Permittivity matrix for the current
             element (e matrix).
-        jacobian_inverted_t: Jacobian matrix inverted and transposed, needed
-            for calculation of global derivatives.
+        element_order: Order of the shape functions.
 
     Returns:
         Float: Integral of epsilonBVe of the current triangle.
     """
     def inner(s):
-        r = local_to_global_coordinates(node_points, s, 0)[0]
-        dn = gradient_local_shape_functions_2d()
+        dn = gradient_local_shape_functions_2d(s, 0, element_order)
+        jacobian = np.dot(node_points, dn.T)
+        jacobian_inverted_t = np.linalg.inv(jacobian).T
+
         global_dn = np.dot(jacobian_inverted_t, dn)
+        r = local_to_global_coordinates(node_points, s, 0, element_order)[0]
 
         return -np.dot(np.dot(permittivity_matrix, global_dn), v_e)*r
 
-    return line_quadrature(inner)
+    return line_quadrature(inner, element_order)
 
 
 def calculate_charge(
@@ -86,7 +92,9 @@ def calculate_charge(
     material_manager: MaterialManager,
     elements: npt.NDArray,
     element_normals: npt.NDArray,
-    nodes
+    nodes: npt.NDArray,
+    element_order: int,
+    is_complex: bool = False
 ) -> float:
     """Calculates the charge of the given elements.
 
@@ -97,28 +105,23 @@ def calculate_charge(
         element_normals: List of element normal vectors (index corresponding to
             the elements list).
         nodes: All nodes used in the simulation.
+        element_order: Order of the shape functions.
     """
+    points_per_element = int(1/2*(element_order+1)*(element_order+2))
     number_of_nodes = len(nodes)
     q = 0
 
     for element_index, element in enumerate(elements):
-        dn = gradient_local_shape_functions_2d()
-        node_points = np.array([
-            [nodes[element[0]][0],
-             nodes[element[1]][0],
-             nodes[element[2]][0]],
-            [nodes[element[0]][1],
-             nodes[element[1]][1],
-             nodes[element[2]][1]],
-        ])
-        # This calculation of the jacobian does only work for triangle elements
-        # and not for line elements, since for line elements the resulting
-        # jacobian is non invertible.
-        jacobian = np.dot(node_points, dn.T)
-        jacobian_inverted_t = np.linalg.inv(jacobian).T
+        node_points = np.zeros(shape=(2, points_per_element))
+        for node_index in range(points_per_element):
+            node_points[:, node_index] = [
+                nodes[element[node_index]][0],
+                nodes[element[node_index]][1]
+            ]
 
         # The integration is always done along the first two points of the
         # triangle.
+        # TODO Not true for element_order > 1
         jacobian_det = np.sqrt(
             np.square(nodes[element[1]][0]-nodes[element[0]][0])
             + np.square(nodes[element[1]][1]-nodes[element[0]][1])
@@ -129,31 +132,29 @@ def calculate_charge(
         # This is due to the charge calculation needing the derivatives of the
         # shape function (dN_i/dr and dN_i/dz) which are (+/-) 1 along the
         # whole triangle for all 3 points.
-        u_e = np.array([
-            u[2*element[0]],
-            u[2*element[0]+1],
-            u[2*element[1]],
-            u[2*element[1]+1],
-            u[2*element[2]],
-            u[2*element[2]+1]
-        ])
-        ve_e = np.array([
-            u[element[0]+2*number_of_nodes],
-            u[element[1]+2*number_of_nodes],
-            u[element[2]+2*number_of_nodes]
-        ])
+        # TODO Is this true?
+        if is_complex:
+            u_e = np.zeros(2*points_per_element, dtype=np.complex128)
+            ve_e = np.zeros(points_per_element, dtype=np.complex128)
+        else:
+            u_e = np.zeros(2*points_per_element)
+            ve_e = np.zeros(points_per_element)
+        for i in range(points_per_element):
+            u_e[2*i] = u[2*element[i]]
+            u_e[2*i+1] = u[2*element[i]+1]
+            ve_e[i] = u[element[i]+2*number_of_nodes]
 
         q_u = charge_integral_u(
             node_points,
             u_e,
             material_manager.get_piezo_matrix(element_index),
-            jacobian_inverted_t
+            element_order
         ) * 2 * np.pi * jacobian_det
         q_v = charge_integral_v(
             node_points,
             ve_e,
             material_manager.get_permittivity_matrix(element_index),
-            jacobian_inverted_t
+            element_order
         ) * 2 * np.pi * jacobian_det
 
         # Now take the component normal to the line (outer direction)
@@ -211,7 +212,7 @@ class PiezoSimTime:
     q: npt.NDArray
 
     # Internal simulation data
-    local_elements: List[LocalElementData]
+    node_points: npt.NDArray
 
     def __init__(
         self,
@@ -232,7 +233,8 @@ class PiezoSimTime:
         # Maybe the 2x2 matrix slicing is not very fast
         nodes = self.mesh_data.nodes
         elements = self.mesh_data.elements
-        self.local_elements = create_local_element_data(nodes, elements)
+        element_order = self.mesh_data.element_order
+        self.node_points = create_node_points(nodes, elements, element_order)
 
         number_of_nodes = len(nodes)
         mu = sparse.lil_matrix(
@@ -253,11 +255,7 @@ class PiezoSimTime:
         )
 
         for element_index, element in enumerate(self.mesh_data.elements):
-            # Get local element nodes and matrices
-            local_element = self.local_elements[element_index]
-            node_points = local_element.node_points
-            jacobian_inverted_t = local_element.jacobian_inverted_t
-            jacobian_det = local_element.jacobian_det
+            node_points = self.node_points[element_index]
 
             # TODO Check if its necessary to calculate all integrals
             # --> Dirichlet nodes could be leaved out?
@@ -266,34 +264,34 @@ class PiezoSimTime:
             # Mutiply with 2*pi because theta is integrated from 0 to 2*pi
             mu_e = (
                 self.material_manager.get_density(element_index)
-                * integral_m(node_points)
-                * jacobian_det * 2 * np.pi
+                * integral_m(node_points, element_order)
+                * 2 * np.pi
             )
             ku_e = (
                 integral_ku(
                     node_points,
-                    jacobian_inverted_t,
-                    self.material_manager.get_elasticity_matrix(element_index)
+                    self.material_manager.get_elasticity_matrix(element_index),
+                    element_order
                 )
-                * jacobian_det * 2 * np.pi
+                * 2 * np.pi
             )
             kuv_e = (
                 integral_kuv(
                     node_points,
-                    jacobian_inverted_t,
-                    self.material_manager.get_piezo_matrix(element_index)
+                    self.material_manager.get_piezo_matrix(element_index),
+                    element_order
                 )
-                * jacobian_det * 2 * np.pi
+                * 2 * np.pi
             )
             kve_e = (
                 integral_kve(
                     node_points,
-                    jacobian_inverted_t,
                     self.material_manager.get_permittivity_matrix(
                         element_index
-                    )
+                    ),
+                    element_order
                 )
-                * jacobian_det * 2 * np.pi
+                * 2 * np.pi
             )
 
             # Now assemble all element matrices
@@ -443,7 +441,8 @@ class PiezoSimTime:
                     self.material_manager,
                     electrode_elements,
                     electrode_normals,
-                    self.mesh_data.nodes
+                    self.mesh_data.nodes,
+                    self.mesh_data.element_order
                 )
 
             if (time_index + 1) % 100 == 0:

--- a/plutho/simulation/piezo_time.py
+++ b/plutho/simulation/piezo_time.py
@@ -139,6 +139,7 @@ def calculate_charge(
         else:
             u_e = np.zeros(2*points_per_element)
             ve_e = np.zeros(points_per_element)
+
         for i in range(points_per_element):
             u_e[2*i] = u[2*element[i]]
             u_e[2*i+1] = u[2*element[i]+1]

--- a/plutho/simulation/piezo_time.py
+++ b/plutho/simulation/piezo_time.py
@@ -9,7 +9,7 @@ import scipy.sparse.linalg as slin
 
 # Local libraries
 from .base import SimulationData, MeshData, \
-    gradient_local_shape_functions, \
+    gradient_local_shape_functions_2d, \
     local_to_global_coordinates, b_operator_global, integral_m, \
     integral_ku, integral_kuv, integral_kve, apply_dirichlet_bc, \
     line_quadrature, create_local_element_data, LocalElementData
@@ -73,7 +73,7 @@ def charge_integral_v(
     """
     def inner(s):
         r = local_to_global_coordinates(node_points, s, 0)[0]
-        dn = gradient_local_shape_functions()
+        dn = gradient_local_shape_functions_2d()
         global_dn = np.dot(jacobian_inverted_t, dn)
 
         return -np.dot(np.dot(permittivity_matrix, global_dn), v_e)*r
@@ -102,7 +102,7 @@ def calculate_charge(
     q = 0
 
     for element_index, element in enumerate(elements):
-        dn = gradient_local_shape_functions(2)
+        dn = gradient_local_shape_functions_2d()
         node_points = np.array([
             [nodes[element[0]][0],
              nodes[element[1]][0],

--- a/plutho/simulation/thermo_piezo_time.py
+++ b/plutho/simulation/thermo_piezo_time.py
@@ -517,7 +517,7 @@ class ThermoPiezoSimTime:
         for element_index, element in enumerate(self.mesh_data.elements):
             node_points = np.zeros(shape=(2, points_per_element))
             for node_index in range(points_per_element):
-                node_points[element_index, :, node_index] = [
+                node_points[:, node_index] = [
                     nodes[element[node_index]][0],
                     nodes[element[node_index]][1]
                 ]

--- a/plutho/simulation/thermo_piezo_time.py
+++ b/plutho/simulation/thermo_piezo_time.py
@@ -10,7 +10,7 @@ from scipy import sparse
 
 # Local libraries
 from .base import SimulationData, MeshData, \
-    gradient_local_shape_functions, create_local_element_data, \
+    gradient_local_shape_functions_2d, create_local_element_data, \
     local_to_global_coordinates, b_operator_global, integral_m, \
     integral_ku, integral_kuv, integral_kve, apply_dirichlet_bc, \
     quadratic_quadrature, LocalElementData, calculate_volumes, \
@@ -512,7 +512,7 @@ class ThermoPiezoSimTime:
         f_theta = np.zeros(number_of_nodes)
 
         for element_index, element in enumerate(self.mesh_data.elements):
-            dn = gradient_local_shape_functions()
+            dn = gradient_local_shape_functions_2d()
             node_points = np.array([
                 [nodes[element[0]][0],
                  nodes[element[1]][0],

--- a/plutho/simulation/thermo_piezo_time.py
+++ b/plutho/simulation/thermo_piezo_time.py
@@ -69,7 +69,13 @@ def loss_integral_scs(
         s_e_t_minus_2 = np.dot(b_opt, u_e_t_minus_2)
         dt_s = (3*s_e-4*s_e_t_minus_1+s_e_t_minus_2)/(2*delta_t)
 
-        return np.dot(dt_s.T, np.dot(elasticity_matrix.T, dt_s))*r*jacobian_det
+        return np.dot(
+            dt_s.T,
+            np.dot(
+                elasticity_matrix.T,
+                dt_s
+            )
+        ) * r * jacobian_det
 
     return quadratic_quadrature(inner, element_order)
 

--- a/plutho/simulation/thermo_piezo_time.py
+++ b/plutho/simulation/thermo_piezo_time.py
@@ -10,11 +10,11 @@ from scipy import sparse
 
 # Local libraries
 from .base import SimulationData, MeshData, \
-    gradient_local_shape_functions_2d, create_local_element_data, \
+    create_node_points, \
     local_to_global_coordinates, b_operator_global, integral_m, \
     integral_ku, integral_kuv, integral_kve, apply_dirichlet_bc, \
-    quadratic_quadrature, LocalElementData, calculate_volumes, \
-    get_avg_temp_field_per_element
+    quadratic_quadrature, calculate_volumes, \
+    gradient_local_shape_functions_2d, get_avg_temp_field_per_element
 from .piezo_time import calculate_charge
 from .thermo_time import integral_ktheta, integral_theta_load
 from ..materials import MaterialManager
@@ -26,8 +26,8 @@ def loss_integral_scs(
     u_e_t_minus_1: npt.NDArray,
     u_e_t_minus_2: npt.NDArray,
     delta_t: float,
-    jacobian_inverted_t: npt.NDArray,
-    elasticity_matrix: npt.NDArray
+    elasticity_matrix: npt.NDArray,
+    element_order: int
 ):
     """Calculates the integral of dS/dt*c*dS/dt over one triangle. Since foward
     difference quotient of second oder is used the last 2 values of e_u are
@@ -47,14 +47,21 @@ def loss_integral_scs(
             for calculation of global derivatives.
         elasticity_matrix: Elasticity matrix for the current element
             (c matrix).
+        element_order: Order of the shape functions.
     """
     def inner(s, t):
-        r = local_to_global_coordinates(node_points, s, t)[0]
+        dn = gradient_local_shape_functions_2d(s, t, element_order)
+        jacobian = np.dot(node_points, dn.T)
+        jacobian_inverted_t = np.linalg.inv(jacobian).T
+        jacobian_det = np.linalg.det(jacobian)
+
+        r = local_to_global_coordinates(node_points, s, t, element_order)[0]
         b_opt = b_operator_global(
             node_points,
             jacobian_inverted_t,
             s,
-            t
+            t,
+            element_order
         )
 
         s_e = np.dot(b_opt, u_e_t)
@@ -62,9 +69,9 @@ def loss_integral_scs(
         s_e_t_minus_2 = np.dot(b_opt, u_e_t_minus_2)
         dt_s = (3*s_e-4*s_e_t_minus_1+s_e_t_minus_2)/(2*delta_t)
 
-        return np.dot(dt_s.T, np.dot(elasticity_matrix.T, dt_s))*r
+        return np.dot(dt_s.T, np.dot(elasticity_matrix.T, dt_s))*r*jacobian_det
 
-    return quadratic_quadrature(inner)
+    return quadratic_quadrature(inner, element_order)
 
 
 class ThermoPiezoSimTime:
@@ -108,9 +115,9 @@ class ThermoPiezoSimTime:
     dirichlet_values: npt.NDArray
 
     # FEM matrices
-    m: npt.NDArray
-    c: npt.NDArray
-    k: npt.NDArray
+    m: sparse.lil_array
+    c: sparse.lil_array
+    k: sparse.lil_array
 
     # Resulting fields
     u: npt.NDArray
@@ -118,7 +125,7 @@ class ThermoPiezoSimTime:
     mech_loss: npt.NDArray
 
     # Internal simulation data
-    local_elements: List[LocalElementData]
+    node_points: npt.NDArray
 
     def __init__(
         self,
@@ -139,7 +146,8 @@ class ThermoPiezoSimTime:
         # Maybe the 2x2 matrix slicing is not very fast
         nodes = self.mesh_data.nodes
         elements = self.mesh_data.elements
-        self.local_elements = create_local_element_data(nodes, elements)
+        element_order = self.mesh_data.element_order
+        self.node_points = create_node_points(nodes, elements, element_order)
 
         number_of_nodes = len(nodes)
         mu = sparse.lil_matrix(
@@ -162,11 +170,7 @@ class ThermoPiezoSimTime:
             dtype=np.float64)
 
         for element_index, element in enumerate(self.mesh_data.elements):
-            # Get local element nodes and matrices
-            local_element = self.local_elements[element_index]
-            node_points = local_element.node_points
-            jacobian_inverted_t = local_element.jacobian_inverted_t
-            jacobian_det = local_element.jacobian_det
+            node_points = self.node_points[element_index]
 
             # TODO Check if its necessary to calculate all integrals
             # --> Dirichlet nodes could be leaved out?
@@ -175,45 +179,45 @@ class ThermoPiezoSimTime:
             # Mutiply with 2*pi because theta is integrated from 0 to 2*pi
             mu_e = (
                 self.material_manager.get_density(element_index)
-                * integral_m(node_points)
-                * jacobian_det * 2 * np.pi
+                * integral_m(node_points, element_order)
+                * 2 * np.pi
             )
             ku_e = (
                 integral_ku(
                     node_points,
-                    jacobian_inverted_t,
-                    self.material_manager.get_elasticity_matrix(element_index))
-                * jacobian_det * 2 * np.pi
+                    self.material_manager.get_elasticity_matrix(element_index),
+                    element_order
+                )
+                * 2 * np.pi
             )
             kuv_e = (
                 integral_kuv(
                     node_points,
-                    jacobian_inverted_t,
-                    self.material_manager.get_piezo_matrix(element_index))
-                * jacobian_det * 2 * np.pi
+                    self.material_manager.get_piezo_matrix(element_index),
+                    element_order
+                )
+                * 2 * np.pi
             )
             kve_e = (
                 integral_kve(
                     node_points,
-                    jacobian_inverted_t,
                     self.material_manager.get_permittivity_matrix(
                         element_index
-                    )
+                    ),
+                    element_order
                 )
-                * jacobian_det * 2 * np.pi
+                * 2 * np.pi
             )
             ctheta_e = (
-                integral_m(node_points)
+                integral_m(node_points, element_order)
                 * self.material_manager.get_density(element_index)
                 * self.material_manager.get_heat_capacity(element_index)
-                * jacobian_det * 2 * np.pi
+                * 2 * np.pi
             )
             ktheta_e = (
-                integral_ktheta(
-                    node_points,
-                    jacobian_inverted_t)
+                integral_ktheta(node_points, element_order)
                 * self.material_manager.get_thermal_conductivity(element_index)
-                * jacobian_det * 2 * np.pi
+                * 2 * np.pi
             )
 
             # Now assemble all element matrices
@@ -303,6 +307,8 @@ class ThermoPiezoSimTime:
         delta_t = self.simulation_data.delta_t
         elements = self.mesh_data.elements
         nodes = self.mesh_data.nodes
+        element_order = self.mesh_data.element_order
+        points_per_element = int(1/2*(element_order+1)*(element_order+2))
         number_of_elements = len(elements)
         number_of_nodes = len(nodes)
 
@@ -336,7 +342,10 @@ class ThermoPiezoSimTime:
             dtype=np.float64
         )
 
-        volumes = calculate_volumes(self.local_elements)
+        volumes = calculate_volumes(
+            self.node_points,
+            self.mesh_data.element_order
+        )
 
         if theta_start is not None:
             if len(theta_start) != number_of_nodes:
@@ -410,39 +419,25 @@ class ThermoPiezoSimTime:
                     self.material_manager,
                     electrode_elements,
                     electrode_normals,
-                    nodes
+                    nodes,
+                    element_order
                 )
 
             # Calculate power_loss
             for element_index, element in enumerate(elements):
-                # Get local element data
-                local_element = self.local_elements[element_index]
-                node_points = local_element.node_points
-                jacobian_inverted_t = local_element.jacobian_inverted_t
-                jacobian_det = local_element.jacobian_det
+                node_points = self.node_points[element_index]
 
-                # Get field values at current element at time index
-                u_e = np.array([
-                    u[2*element[0], time_index+1],
-                    u[2*element[0]+1, time_index+1],
-                    u[2*element[1], time_index+1],
-                    u[2*element[1]+1, time_index+1],
-                    u[2*element[2], time_index+1],
-                    u[2*element[2]+1, time_index+1]])
-                u_e_t_minus_1 = np.array([
-                    u[2*element[0], time_index],
-                    u[2*element[0]+1, time_index],
-                    u[2*element[1], time_index],
-                    u[2*element[1]+1, time_index],
-                    u[2*element[2], time_index],
-                    u[2*element[2]+1, time_index]])
-                u_e_t_minus_2 = np.array([
-                    u[2*element[0], time_index-1],
-                    u[2*element[0]+1, time_index-1],
-                    u[2*element[1], time_index-1],
-                    u[2*element[1]+1, time_index-1],
-                    u[2*element[2], time_index-1],
-                    u[2*element[2]+1, time_index-1]])
+                # Get field values at current element at specific time index
+                u_e = np.zeros(2*points_per_element)
+                u_e_t_minus_1 = np.zeros(2*points_per_element)
+                u_e_t_minus_2 = np.zeros(2*points_per_element)
+                for i in range(points_per_element):
+                    u_e[2*i] = u[2*element[i], time_index+1]
+                    u_e[2*i+1] = u[2*element[i]+1, time_index+1]
+                    u_e_t_minus_1[2*i] = u[2*element[i], time_index]
+                    u_e_t_minus_1[2*i+1] = u[2*element[i]+1, time_index]
+                    u_e_t_minus_2[2*i] = u[2*element[i], time_index-1]
+                    u_e_t_minus_2[2*i+1] = u[2*element[i]+1, time_index-1]
 
                 # The mech loss of the element is divided by the volume
                 # because it must be a power density.
@@ -454,12 +449,12 @@ class ThermoPiezoSimTime:
                             u_e_t_minus_1,
                             u_e_t_minus_2,
                             delta_t,
-                            jacobian_inverted_t,
                             self.material_manager.get_elasticity_matrix(
                                 element_index
-                            )
+                            ),
+                            element_order
                         )
-                        * 2 * np.pi * jacobian_det
+                        * 2 * np.pi
                         * self.material_manager.get_alpha_k(element_index)
                         * 1/volumes[element_index]
                     )
@@ -496,6 +491,8 @@ class ThermoPiezoSimTime:
         # For the temperature field the load vector represents the temperature
         # sources given by the mechanical losses.
         nodes = self.mesh_data.nodes
+        element_order = self.mesh_data.element_order
+        points_per_element = int(1/2*(element_order+1)*(element_order+2))
         number_of_nodes = len(nodes)
 
         # Can be initialized to 0 because external load and volume charge
@@ -512,21 +509,18 @@ class ThermoPiezoSimTime:
         f_theta = np.zeros(number_of_nodes)
 
         for element_index, element in enumerate(self.mesh_data.elements):
-            dn = gradient_local_shape_functions_2d()
-            node_points = np.array([
-                [nodes[element[0]][0],
-                 nodes[element[1]][0],
-                 nodes[element[2]][0]],
-                [nodes[element[0]][1],
-                 nodes[element[1]][1],
-                 nodes[element[2]][1]]
-            ])
-            jacobian = np.dot(node_points, dn.T)
-            jacobian_det = np.linalg.det(jacobian)
+            node_points = np.zeros(shape=(2, points_per_element))
+            for node_index in range(points_per_element):
+                node_points[element_index, :, node_index] = [
+                    nodes[element[node_index]][0],
+                    nodes[element[node_index]][1]
+                ]
 
             f_theta_e = integral_theta_load(
                 node_points,
-                mech_loss_density[element_index])*2*np.pi*jacobian_det
+                mech_loss_density[element_index],
+                element_order
+            ) * 2 * np.pi
 
             for local_p, global_p in enumerate(element):
                 f_theta[global_p] += f_theta_e[local_p]

--- a/plutho/simulation/thermo_time.py
+++ b/plutho/simulation/thermo_time.py
@@ -10,8 +10,8 @@ import scipy.sparse.linalg as slin
 from scipy import sparse
 
 # Local libraries
-from .base import SimulationData, MeshData, \
-    local_shape_functions, gradient_local_shape_functions, \
+from .base import SimulationData, MeshData, local_shape_functions_1d, \
+    local_shape_functions_2d, gradient_local_shape_functions_2d, \
     local_to_global_coordinates, integral_m, LocalElementData, \
     quadratic_quadrature, line_quadrature, create_local_element_data, \
     apply_dirichlet_bc, get_avg_temp_field_per_element
@@ -31,7 +31,7 @@ def integral_heat_flux(
     Returns:
         npt.NDArray heat flux integral on each point."""
     def inner(s):
-        n = local_shape_functions(s)
+        n = local_shape_functions_1d(s)
         r = local_to_global_coordinates(node_points, s)[0]
 
         return n*heat_flux*r
@@ -54,7 +54,7 @@ def integral_ktheta(
         npt.NDArray: 3x3 Ktheta matrix for the given element.
     """
     def inner(s, t):
-        dn = gradient_local_shape_functions()
+        dn = gradient_local_shape_functions_2d()
         global_dn = np.dot(jacobian_inverted_t, dn)
         r = local_to_global_coordinates(node_points, s, t)[0]
 
@@ -77,7 +77,7 @@ def integral_theta_load(
         npt.NDArray: f vector value at the specific ndoe
     """
     def inner(s, t):
-        n = local_shape_functions(s, t)
+        n = local_shape_functions_2d(s, t)
         r = local_to_global_coordinates(node_points, s, t)[0]
         return n*mech_loss*r
 
@@ -154,7 +154,7 @@ class ThermoSimTime:
             dtype=np.float64)
 
         for element in self.mesh_data.elements:
-            dn = gradient_local_shape_functions()
+            dn = gradient_local_shape_functions_2d()
             # Get node points of element in format
             # [x1 x2 x3]
             # [y1 y2 y3] where (xi, yi) are the coordinates for Node i
@@ -211,7 +211,7 @@ class ThermoSimTime:
         f = np.zeros(shape=(number_of_nodes, number_of_time_steps))
         for time_step in range(number_of_time_steps):
             for element_index, element in enumerate(self.mesh_data.elements):
-                dn = gradient_local_shape_functions()
+                dn = gradient_local_shape_functions_2d()
                 node_points = np.array([
                     [nodes[element[0]][0],
                      nodes[element[1]][0],
@@ -252,7 +252,7 @@ class ThermoSimTime:
         f = np.zeros(number_of_nodes)
 
         for element_index, element in enumerate(self.mesh_data.elements):
-            dn = gradient_local_shape_functions()
+            dn = gradient_local_shape_functions_2d()
             node_points = np.array([
                 [nodes[element[0]][0],
                  nodes[element[1]][0],

--- a/plutho/simulation/thermo_time.py
+++ b/plutho/simulation/thermo_time.py
@@ -91,7 +91,7 @@ def integral_theta_load(
         jacobian = np.dot(node_points, dn.T)
         jacobian_det = np.linalg.det(jacobian)
 
-        n = local_shape_functions_2d(s, t)
+        n = local_shape_functions_2d(s, t, element_order)
         r = local_to_global_coordinates(node_points, s, t, element_order)[0]
 
         return n*mech_loss*r*jacobian_det
@@ -174,8 +174,8 @@ class ThermoSimTime:
 
             ctheta_e = (
                 integral_m(node_points, element_order)
-                * self.material_manager.get_density(element)
-                * self.material_manager.get_heat_capacity(element)
+                * self.material_manager.get_density(element_index)
+                * self.material_manager.get_heat_capacity(element_index)
                 * 2 * np.pi
             )
             ktheta_e = (
@@ -183,7 +183,7 @@ class ThermoSimTime:
                     node_points,
                     element_order
                 )
-                * self.material_manager.get_thermal_conductivity(element)
+                * self.material_manager.get_thermal_conductivity(element_index)
                 * 2 * np.pi
             )
 
@@ -207,7 +207,7 @@ class ThermoSimTime:
         Parameters:
             mech_loss_density: The mechanical losses for each element. They
                 will be applied for every time step.
-            number_of_time_steps: Total number of time steps
+            number_of_time_steps: Total number of time steps.
         """
         nodes = self.mesh_data.nodes
         element_order = self.mesh_data.element_order
@@ -529,4 +529,5 @@ class ThermoSimTime:
             if self.material_manager.update_temperature(
                     temp_field_per_element):
                 return time_index+1
+
         return number_of_time_steps

--- a/plutho/simulation/thermo_time.py
+++ b/plutho/simulation/thermo_time.py
@@ -34,10 +34,6 @@ def integral_heat_flux(
         npt.NDArray heat flux integral on each point.
     """
     def inner(s):
-        dn = gradient_local_shape_functions_2d(s, 0, element_order)
-        jacobian = np.dot(node_points, dn.T)
-        jacobian_det = np.linalg.det(jacobian)
-
         n = local_shape_functions_2d(s, 0, element_order)
         r = local_to_global_coordinates(node_points, s, 0, element_order)[0]
 
@@ -411,7 +407,8 @@ class ThermoSimTime:
                     self.convective_b_e,
                     theta[:, time_index],
                     self.convective_alpha,
-                    self.convective_outer_temp
+                    self.convective_outer_temp,
+                    self.mesh_data.element_order
                 )
 
             # Perform Newmark method

--- a/plutho/simulation/thermo_time.py
+++ b/plutho/simulation/thermo_time.py
@@ -120,6 +120,10 @@ class ThermoSimTime:
     theta: npt.NDArray
     f: npt.NDArray
 
+    # FEM Matrices
+    k: sparse.lil_array
+    c: sparse.lil_array
+
     # Convective bc
     enable_convection_bc: bool
     convective_b_e: List[int]
@@ -439,7 +443,7 @@ class ThermoSimTime:
         self,
         initial_theta_field: npt.NDArray,
         initial_time_step: int
-    ):
+    ) -> int:
         """Runs the simulation using the assembled c and k matrices as well
         as the set excitation.
         Calculates the temperature field and saves it in theta.
@@ -492,12 +496,13 @@ class ThermoSimTime:
             # Add a convection boundary condition if it set
             if self.enable_convection_bc:
                 f += self._calculate_convection_bc(
-                    self.mesh_data.nodes,
-                    self.convective_b_e,
-                    self.theta[:, time_index],
-                    self.convective_alpha,
-                    self.convective_outer_temp
-                )
+                self.mesh_data.nodes,
+                self.convective_b_e,
+                self.theta[:, time_index],
+                self.convective_alpha,
+                self.convective_outer_temp,
+                self.mesh_data.element_order
+            )
 
             # Perform Newmark method
             # Predictor step

--- a/plutho/single_sim.py
+++ b/plutho/single_sim.py
@@ -86,7 +86,7 @@ class SingleSimulation:
         self.mesh = mesh
 
         nodes, elements = mesh.get_mesh_nodes_and_elements()
-        self.mesh_data = MeshData(nodes, elements)
+        self.mesh_data = MeshData(nodes, elements, mesh.element_order)
         self.material_manager = MaterialManager(len(elements))
         self.charge_calculated = False
         self.mech_loss_calculated = False

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -52,7 +52,7 @@ def test_thermo_time(tmp_path):
     the simulation and compares it with the input energy.
     """
     # Create and load mesh; TODO maybe use smaller mesh size?
-    element_order = 2
+    element_order = 1
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
     plutho.Mesh.generate_rectangular_mesh(
         mesh_path,
@@ -315,7 +315,10 @@ def test_thermo_piezo_time(tmp_path, test=True):
     # Create and load mesh; TODO maybe use smaller mesh size?
     element_order = 1
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
-    plutho.Mesh.generate_rectangular_mesh(mesh_path)
+    plutho.Mesh.generate_rectangular_mesh(
+        mesh_path,
+        element_order=element_order
+    )
     mesh = plutho.Mesh(mesh_path, element_order)
 
     sim = plutho.SingleSimulation(

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -52,9 +52,12 @@ def test_thermo_time(tmp_path):
     the simulation and compares it with the input energy.
     """
     # Create and load mesh; TODO maybe use smaller mesh size?
-    element_order = 1
+    element_order = 2
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
-    plutho.Mesh.generate_rectangular_mesh(mesh_path)
+    plutho.Mesh.generate_rectangular_mesh(
+        mesh_path,
+        element_order=element_order
+    )
     mesh = plutho.Mesh(mesh_path, element_order)
 
     sim = plutho.SingleSimulation(
@@ -68,6 +71,9 @@ def test_thermo_time(tmp_path):
     delta_t = 0.001
     nodes, elements = mesh.get_mesh_nodes_and_elements()
     number_of_elements = len(elements)
+
+    print(f"Nodes {nodes}")
+    print(f"Elements {elements}")
 
     sim.setup_thermo_time_domain(
         delta_t,
@@ -118,9 +124,13 @@ def test_piezo_time(tmp_path, test=True):
     """Test function for the piezo time domain simulation.
     Tests the simulation for a triangular excitation."""
     # Create and load mesh; TODO maybe use smaller mesh size?
+    element_order = 1
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
-    plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path, element_order=1)
+    plutho.Mesh.generate_rectangular_mesh(
+        mesh_path,
+        element_order=element_order
+    )
+    mesh = plutho.Mesh(mesh_path, element_order)
 
     sim = plutho.SingleSimulation(
         tmp_path,
@@ -212,9 +222,13 @@ def test_piezo_freq(tmp_path, test=True):
     displacement field and charge for a sinusoidal signal.
     """
     # Create and load mesh; TODO maybe use smaller mesh size?
+    element_order = 1
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
-    plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path, element_order=1)
+    plutho.Mesh.generate_rectangular_mesh(
+        mesh_path,
+        element_order=element_order
+    )
+    mesh = plutho.Mesh(mesh_path, element_order)
 
     sim = plutho.SingleSimulation(
         tmp_path,

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -299,9 +299,10 @@ def test_thermo_piezo_time(tmp_path, test=True):
     last time step are compared with fixed results.
     """
     # Create and load mesh; TODO maybe use smaller mesh size?
+    element_order = 1
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
     plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path, element_order=1)
+    mesh = plutho.Mesh(mesh_path, element_order)
 
     sim = plutho.SingleSimulation(
         tmp_path,
@@ -376,7 +377,7 @@ def test_thermo_piezo_time(tmp_path, test=True):
 
     # Calculate total loss energy
     volumes = plutho.simulation.base.calculate_volumes(
-        sim.solver.local_elements
+        sim.solver.node_points, element_order
     )
     power = np.zeros(NUMBER_OF_TIME_STEPS)
     for time_step in range(NUMBER_OF_TIME_STEPS):
@@ -394,6 +395,7 @@ def test_thermo_piezo_time(tmp_path, test=True):
         theta[:, -1],
         nodes,
         elements,
+        element_order,
         sim.material_manager.get_heat_capacity(0),
         sim.material_manager.get_density(0)
     )

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -52,9 +52,10 @@ def test_thermo_time(tmp_path):
     the simulation and compares it with the input energy.
     """
     # Create and load mesh; TODO maybe use smaller mesh size?
+    element_order = 1
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
     plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path, element_order=1)
+    mesh = plutho.Mesh(mesh_path, element_order)
 
     sim = plutho.SingleSimulation(
         tmp_path,
@@ -93,12 +94,16 @@ def test_thermo_time(tmp_path):
         sim.solver.theta[:, -1],
         nodes,
         elements,
+        element_order,
         sim.material_manager.get_heat_capacity(0),
         sim.material_manager.get_density(0)
     )
 
     volume = np.sum(
-        plutho.simulation.base.calculate_volumes(sim.solver.local_elements)
+        plutho.simulation.base.calculate_volumes(
+            sim.solver.node_points,
+            element_order
+        )
     )
 
     input_energy = INPUT_POWER_DENSITY*volume

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -54,7 +54,7 @@ def test_thermo_time(tmp_path):
     # Create and load mesh; TODO maybe use smaller mesh size?
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
     plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path)
+    mesh = plutho.Mesh(mesh_path, element_order=1)
 
     sim = plutho.SingleSimulation(
         tmp_path,
@@ -115,7 +115,7 @@ def test_piezo_time(tmp_path, test=True):
     # Create and load mesh; TODO maybe use smaller mesh size?
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
     plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path)
+    mesh = plutho.Mesh(mesh_path, element_order=1)
 
     sim = plutho.SingleSimulation(
         tmp_path,
@@ -209,7 +209,7 @@ def test_piezo_freq(tmp_path, test=True):
     # Create and load mesh; TODO maybe use smaller mesh size?
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
     plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path)
+    mesh = plutho.Mesh(mesh_path, element_order=1)
 
     sim = plutho.SingleSimulation(
         tmp_path,
@@ -296,7 +296,7 @@ def test_thermo_piezo_time(tmp_path, test=True):
     # Create and load mesh; TODO maybe use smaller mesh size?
     mesh_path = os.path.join(tmp_path, "default_mesh.msh")
     plutho.Mesh.generate_rectangular_mesh(mesh_path)
-    mesh = plutho.Mesh(mesh_path)
+    mesh = plutho.Mesh(mesh_path, element_order=1)
 
     sim = plutho.SingleSimulation(
         tmp_path,


### PR DESCRIPTION
Add quadratic and cubic shape functions. The shape functions are implemented explicitly therefore even higher shape functions are not yet supported.
Nevertheless all simulations have been updated to handle higher order shape functions, therefore implementing shape functions of order 4 and higher should be done more easily.
Additionally some functions in the gmsh mesh parsing have been changed since they always assumed linear shape functions.


Tests are still using linear shape functions but the higher order shape function have been tested separately.
